### PR TITLE
hotfix: javascript fix to open surveys (since wkwebview doesnt like window.open) 

### DIFF
--- a/PeanutLabs-iOS/Classes/PeanutLabsContentView/PeanutLabsContentViewController.swift
+++ b/PeanutLabs-iOS/Classes/PeanutLabsContentView/PeanutLabsContentViewController.swift
@@ -241,13 +241,19 @@ extension PeanutLabsContentViewController: UIWebViewDelegate {
     
 }
 
-/**
- Temp removed and switch to UIWebView due to CORS issue with WKWebView
- **/
 
 extension PeanutLabsContentViewController: WKNavigationDelegate {
     
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        
+        // Fix for WKWebView ignoring window.open requests in JS
+        webView.evaluateJavaScript("""
+            window.open = function(open) {
+                return function (url, name, features) {
+                    window.location.href = url;
+                    return window;
+                }; } (window.open);
+            """, completionHandler: nil)
         
         PeanutLabsLogger.default.log(message: "decidePolicyFor", for: .debug)
   


### PR DESCRIPTION
This can be a temporary fix to address survey's inability to open surveys in the current sdk incarnation. I can add (on pl side) an exit button to return to the reward center for those visiting from the sdk, but that should only be a temporary fix that could be better handled by some notes I put down below.

**_what this PR does:_**
* adds some javascript for webview to execute to open new window requests in same window instead since wkwebview blocks window.open/target=_blank requests

**_what this PR does not do_**
* once in a survey/presurvey, a user cannot exit the survey
  * ideally, surveys would open in another ViewController maybe? with appropriate nav to allow users to exit if they see fit
  * can't really control this internally since the survey's html/js code can be from any number of different places
* once a survey is complete, a user cannot return to the reward center
  * i can update the landing page to include an exit button as a temporary fix, but the above should be a better fix

**_other anomalies_** 
* aspect view of some surveys (especially from external sources) can get funky: 
![image](https://user-images.githubusercontent.com/48297697/97037266-0cf99580-1537-11eb-8fca-edbdbe2f07a2.png)
![image](https://user-images.githubusercontent.com/48297697/97037297-184cc100-1537-11eb-88a9-a951781c63d9.png)

